### PR TITLE
🚸 Rename org name from OpenLNMetrics to LNOpenMetrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # lnmetrics.utils
-The collection of util function and wrapper interface around go libraris user in the OpenLNMetrics project
+The collection of util function and wrapper interface around go libraris user in the LNOpenMetrics project

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/OpenLNMetrics/lnmetrics.utils
+module github.com/LNOpenMetrics/lnmetrics.utils
 
 go 1.15
 


### PR DESCRIPTION
Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>